### PR TITLE
Replace `saved_to_cache` with a more accurate `fetched_from_cache` in CachingQuery

### DIFF
--- a/recipe_caching/__init__.py
+++ b/recipe_caching/__init__.py
@@ -3,6 +3,7 @@
 Recipe
 ~~~~~~~~~~~~~~~~~~~~~
 """
+import functools
 import logging
 
 from recipe_caching.caching_query import CachingQuery
@@ -21,11 +22,7 @@ logging.getLogger(__name__).addHandler(NullHandler())
 
 
 def query_callable(regions, query_cls=CachingQuery):
-
-    def query(*arg, **kw):
-        return query_cls(regions, *arg, **kw)
-
-    return query
+    return functools.partial(query_cls, regions)
 
 
 __all__ = [query_callable]

--- a/recipe_caching/caching_query.py
+++ b/recipe_caching/caching_query.py
@@ -14,7 +14,6 @@ from dogpile.cache.api import NO_VALUE
 from redis.exceptions import ConnectionError, LockError as RedisLockError
 from dogpile.util.readwrite_lock import LockError as DogpileLockError
 from sqlalchemy.orm.query import Query
-from six import text_type
 
 from recipe.utils import clean_unicode
 

--- a/recipe_caching/caching_query.py
+++ b/recipe_caching/caching_query.py
@@ -71,8 +71,7 @@ class CachingQuery(Query):
             key = self._cache_region.cache_key
         else:
             key = _key_from_query(self)
-        if getattr(self._cache_region, 'cache_prefix'):
-            key = '{}:{}'.format(self._cache_region.cache_prefix, key)
+        key = '{}:{}'.format(self._cache_region.cache_prefix, key)
         return dogpile_region, key
 
     def invalidate(self):

--- a/recipe_caching/caching_query.py
+++ b/recipe_caching/caching_query.py
@@ -158,5 +158,5 @@ def _key_from_query(query, qualifier=None):
 
     # here we return the key as a long string.  our "key mangler"
     # set up with the region will boil it down to an md5.
-    return ' '.join([clean_unicode(text_type(compiled)).decode('utf-8')] +
+    return ' '.join([clean_unicode(compiled).decode('utf-8')] +
                     [clean_unicode(params[k]).decode('utf-8') for k in sorted(params)])

--- a/recipe_caching/caching_query.py
+++ b/recipe_caching/caching_query.py
@@ -42,7 +42,7 @@ class CachingQuery(Query):
 
     def __init__(self, regions, *args, **kw):
         self.cache_regions = regions
-        self.saved_to_cache = False
+        self.fetched_from_cache = False
         Query.__init__(self, *args, **kw)
 
     def __iter__(self):
@@ -57,7 +57,6 @@ class CachingQuery(Query):
            modified to first expunge() each loaded item from the current
            session before returning the list of items, so that the items
            in the cache are not the same ones in the current Session.
-
         """
         if hasattr(self, '_cache_region'):
             return self.get_value(
@@ -68,7 +67,6 @@ class CachingQuery(Query):
 
     def _get_cache_plus_key(self):
         """Return a cache region plus key."""
-
         dogpile_region = self.cache_regions[self._cache_region.region]
         if self._cache_region.cache_key:
             key = self._cache_region.cache_key
@@ -80,7 +78,6 @@ class CachingQuery(Query):
 
     def invalidate(self):
         """Invalidate the cache value represented by this Query."""
-
         dogpile_region, cache_key = self._get_cache_plus_key()
         dogpile_region.delete(cache_key)
 
@@ -95,7 +92,6 @@ class CachingQuery(Query):
 
         Raise KeyError if no value present and no
         createfunc specified.
-
         """
         dogpile_region, cache_key = self._get_cache_plus_key()
 
@@ -106,6 +102,7 @@ class CachingQuery(Query):
         assert not ignore_expiration or not createfunc, \
             "Can't ignore expiration and also provide createfunc"
 
+        ran_createfunc = []
         if ignore_expiration or not createfunc:
             cached_value = dogpile_region.get(
                 cache_key,
@@ -113,20 +110,26 @@ class CachingQuery(Query):
                 ignore_expiration=ignore_expiration
             )
         else:
+            def create_wrapper():
+                # When we switch all the way to Python 3, this should use `nonlocal`
+                ran_createfunc.append(True)
+                return createfunc()
+
             try:
                 cached_value = dogpile_region.get_or_create(
-                    cache_key, createfunc, expiration_time=expiration_time
+                    cache_key, create_wrapper, expiration_time=expiration_time
                 )
             except ConnectionError:
                 logger.error('Cannot connect to query caching backend!')
-                cached_value = createfunc()
+                cached_value = create_wrapper()
             except (RedisLockError, DogpileLockError) as exc_info:
                 logger.warn('Lock is not longer available: {}'.format(exc_info))
-                cached_value = createfunc()
+                cached_value = create_wrapper()
         if cached_value is NO_VALUE:
             raise KeyError(cache_key)
         if merge:
             cached_value = self.merge_result(cached_value, load=False)
+        self.fetched_from_cache = not ran_createfunc
         return cached_value
 
     def set_value(self, value):
@@ -134,7 +137,6 @@ class CachingQuery(Query):
         dogpile_region, cache_key = self._get_cache_plus_key()
         try:
             dogpile_region.set(cache_key, value)
-            self.saved_to_cache = True
         except ConnectionError:
             logger.error('Cannot connect to query caching backend!')
 


### PR DESCRIPTION
## Changes

- Set a `fetched_from_cache` attribute on the Query objects to `False` when we actually run a query, and `True` when we don't.
- Copy caching_query changes from fruition to here
  - handle redis LockErrors and dogpile LockErrors by ignoring them & running the query
  - some py3 string munging fixes
  - add a cache_prefix to cache keys
    - NOTE: I did this slightly different from the way this was originally written in fruition because it didn't seem to make sense, but behaviorally it should be identical. Please see these comments:
      - https://github.com/juiceinc/recipe_caching/commit/c8018f2cf9deef05963dbdc282021cb53353f992
      - https://github.com/juiceinc/recipe_caching/commit/a224a51a1c606bb272b57ee7235cd55b66811a07
- super bikesheddy simplification of `query_callable`
