### PR TITLE
Remove flapjack-stack requirement

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,4 +4,3 @@ recipe>=0.7.2
 sqlalchemy
 redis
 dogpile.cache
-flapjack-stack

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ decorator==4.4.0          # via dogpile.cache
 dogpile.cache==0.7.1
 et-xmlfile==1.0.1         # via openpyxl
 faker==1.0.7              # via recipe
-flapjack-stack==1.0.0
 ipaddress==1.0.22         # via faker
 jdcal==1.3                # via openpyxl
 odfpy==1.3.5              # via tablib
@@ -19,7 +18,7 @@ orderedset==2.0           # via recipe
 pbr==5.2.1                # via stevedore
 python-dateutil==2.8.0    # via dateparser, faker
 pytz==2019.1              # via dateparser, tzlocal
-pyyaml==3.12              # via flapjack-stack, recipe, tablib
+pyyaml>=4.2b1
 recipe==0.7.2
 redis==2.10.6
 regex==2019.6.8           # via dateparser

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ install = [
     'sqlalchemy',
     'redis',
     'dogpile.cache',
-    'flapjack-stack'
 ]
 # yapf: enable
 


### PR DESCRIPTION
Removes the flapjack_stack dependency. This adds some complexity that we don't need and pins a version of pyyaml that is insecure.