### PR TITLE
add-option-to-disable-print-sql-reindent

### DIFF
--- a/recipe_caching/__init__.py
+++ b/recipe_caching/__init__.py
@@ -8,8 +8,8 @@ import functools
 from recipe_caching.caching_query import CachingQuery
 
 
-def query_callable(regions, query_cls=CachingQuery):
-    return functools.partial(query_cls, regions)
+def query_callable(regions, query_cls=CachingQuery, **kwargs):
+    return functools.partial(query_cls, regions, **kwargs)
 
 
 __all__ = [query_callable]

--- a/recipe_caching/caching_query.py
+++ b/recipe_caching/caching_query.py
@@ -39,7 +39,7 @@ class CachingQuery(Query):
     def __init__(self, regions, *args, **kw):
         self.cache_regions = regions
         self.fetched_from_cache = False
-        self.format_log_sql = kw.pop("format_log_sql", False)
+        self.format_log_sql = kw.pop("format_log_sql", True)
         Query.__init__(self, *args, **kw)
 
     def __iter__(self):

--- a/recipe_caching/caching_query.py
+++ b/recipe_caching/caching_query.py
@@ -39,6 +39,7 @@ class CachingQuery(Query):
     def __init__(self, regions, *args, **kw):
         self.cache_regions = regions
         self.fetched_from_cache = False
+        self.format_log_sql = kw.pop('format_log_sql', False)
         Query.__init__(self, *args, **kw)
 
     def __iter__(self):
@@ -60,7 +61,7 @@ class CachingQuery(Query):
             return self._log_and_query()
 
     def _log_and_query(self):
-        SLOG.debug("execute-query", sql=prettyprintable_sql(self))
+        SLOG.info("execute-query", sql=prettyprintable_sql(self, reindent=self.format_log_sql))
         return Query.__iter__(self)
 
     def _get_cache_plus_key(self):

--- a/recipe_caching/caching_query.py
+++ b/recipe_caching/caching_query.py
@@ -39,7 +39,7 @@ class CachingQuery(Query):
     def __init__(self, regions, *args, **kw):
         self.cache_regions = regions
         self.fetched_from_cache = False
-        self.format_log_sql = kw.pop('format_log_sql', False)
+        self.format_log_sql = kw.pop("format_log_sql", False)
         Query.__init__(self, *args, **kw)
 
     def __iter__(self):
@@ -61,7 +61,9 @@ class CachingQuery(Query):
             return self._log_and_query()
 
     def _log_and_query(self):
-        SLOG.info("execute-query", sql=prettyprintable_sql(self, reindent=self.format_log_sql))
+        SLOG.info(
+            "execute-query", sql=prettyprintable_sql(self, reindent=self.format_log_sql)
+        )
         return Query.__iter__(self)
 
     def _get_cache_plus_key(self):

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -125,7 +125,7 @@ GROUP BY first"""
        sum(foo.age) AS age
 FROM foo
 GROUP BY last
-ORDER BY foo.last"""
+ORDER BY last"""
         )
         assert recipe.all()[0].last == "fred"
         assert recipe.all()[0].age == 10

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -150,7 +150,7 @@ ORDER BY foo.last"""
        sum(foo.age) AS age
 FROM foo
 GROUP BY last
-ORDER BY foo.last"""
+ORDER BY last"""
         )
         assert recipe.all()[0].last == "fred"
         assert recipe.all()[0].age == 10


### PR DESCRIPTION
* Adds a kwargs to `CachingQuery.__init__` to allow disabling sql log reindent
* Change logging in `_log_and_query` from debug to info. debug will be silenced in deployment envs.